### PR TITLE
Install python3 as part of the image

### DIFF
--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -13,6 +13,7 @@ RUN INSTALL_PKGS=" \
 	tcpdump libpcap \
 	iproute iputils strace socat \
 	frr \
+	python3 \
         " && \
 	yum install -y --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False $INSTALL_PKGS
 


### PR DESCRIPTION
Python3 is required and called when metallb wants to reload the configuration, to call the reloader script.

