### PR TITLE
Add tini package to FRR container

### DIFF
--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -19,6 +19,12 @@ RUN INSTALL_PKGS=" \
 
 RUN dnf -y update && yum clean all && rm -rf /var/cache/yum/* && rm -rf /var/cache/yum
 
+# Add tini package
+ENV TINI_VERSION v0.19.0
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /sbin/tini
+RUN chmod +x /sbin/tini
+
+
 # frr.sh is the entry point. This script examines environment
 # variables to direct operation and configure ovn
 ADD frr.sh /root/


### PR DESCRIPTION
Signed-off-by: Mohamed Mahmoud <mmahmoud@redhat.com>
FRR container is not starting 
```
/bin/sh: /sbin/tini: No such file or directory
tail: cannot open '/etc/frr/frr.log' for reading: No such file or directory
tail: no files remaining
```