### PR TITLE
Add docker-start to FRR container Dockerfile

### DIFF
--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -36,3 +36,6 @@ RUN chown frr:frr /etc/frr/daemons /etc/frr/frr.conf
 
 WORKDIR /root
 ENTRYPOINT ["/root/frr.sh", "frr-node"]
+
+COPY docker-start /usr/lib/frr/docker-start
+CMD ["/usr/lib/frr/docker-start"]

--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -35,7 +35,7 @@ ADD vtysh.conf /etc/frr
 RUN chown frr:frr /etc/frr/daemons /etc/frr/frr.conf 
 
 WORKDIR /root
-ENTRYPOINT ["/root/frr.sh", "frr-node"]
+ENTRYPOINT ["/sbin/tini", "--"]
 
 COPY docker-start /usr/lib/frr/docker-start
 CMD ["/usr/lib/frr/docker-start"]

--- a/docker-start
+++ b/docker-start
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+source /usr/lib/frr/frrcommon.sh
+/usr/lib/frr/watchfrr $(daemon_list)


### PR DESCRIPTION
This should solve the following error:

```
sh-4.2$ ./kubectl logs -n metallb-system speaker-jbknj frr
I1205 11:23:19.478158     247 request.go:665] Waited for 1.012007096s due to client-side throttling, not priority and fairness, request: GET:https://api.ostest.test.metalkube.org:6443/apis/flowcontrol.apiserver.k8s.io/v1beta1?timeout=32s
[FATAL tini (419)] exec /usr/lib/frr/docker-start failed: No such file or directory
```