### PR TITLE
OCPBUGS-24598: Dockerfile: remove tini-static

### DIFF
--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -19,6 +19,7 @@ RUN INSTALL_PKGS=" \
 	yum install -y --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False $INSTALL_PKGS
 
 RUN dnf -y update && yum clean all && rm -rf /var/cache/yum/* && rm -rf /var/cache/yum
+RUN rm /usr/bin/tini-static # make the container fips compliant
 
 # frr.sh is the entry point. This script examines environment
 # variables to direct operation and configure ovn


### PR DESCRIPTION
Both tini and tini-static are container in the same rpm and dnf installs both, but we use only tini. So here we zap tini-static to avoid it raising false alarms on fips compliance.