### PR TITLE
catatonit: install podman-catatonit

### DIFF
--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -41,7 +41,7 @@ RUN INSTALL_PKGS=" \
 	iproute iputils strace socat \
 	frr \
 	python3 \
-	catatonit" && \
+	podman-catatonit" && \
 	yum install -y --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False $INSTALL_PKGS
 
 RUN dnf -y update && yum clean all && rm -rf /var/cache/yum/* && rm -rf /var/cache/yum


### PR DESCRIPTION
Both on rhel9.4, and scos,
running dnf install catatonit results in an unresolved podman dependency, while podman-catatonit works and is newer.
