### PR TITLE
OCPBUGS-55343: OpenShift Only: TEMPORARY: pin FRR version to known working rpm

### DIFF
--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -39,12 +39,13 @@ ENV PYTHONDONTWRITEBYTECODE yes
 RUN INSTALL_PKGS=" \
 	tcpdump libpcap \
 	iproute iputils strace socat \
-	frr \
 	python3 \
 	podman-catatonit" && \
 	yum install -y --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False $INSTALL_PKGS
 
-RUN dnf -y update && yum clean all && rm -rf /var/cache/yum/* && rm -rf /var/cache/yum
+RUN dnf -y update && \
+yum install -y --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False frr-8.5.3-4.el9 && \
+yum clean all && rm -rf /var/cache/yum/* && rm -rf /var/cache/yum
 
 # frr.sh is the entry point. This script examines environment
 # variables to direct operation and configure ovn


### PR DESCRIPTION
There are multiple issues around the latest 8.5.3-4.el9_4.2 related to BFD, we pin the version to the known good one until it is fixed, otherwise we keep shipping a non-working image.


(cherry picked from commit 718c260720fbb590c956d9aa85b1466663a712df)

