### PR TITLE
[release-4.19] Backport frrk8s hostnetworked

### DIFF
--- a/charts/frr-k8s/README.md
+++ b/charts/frr-k8s/README.md
@@ -71,7 +71,7 @@ Kubernetes: `>= 1.19.0-0`
 | frrk8s.tolerateMaster | bool | `true` |  |
 | frrk8s.tolerations | list | `[]` |  |
 | frrk8s.updateStrategy.type | string | `"RollingUpdate"` |  |
-| frrk8s.webhookPort | int | `9443` |  |
+| frrk8s.webhookPort | int | `19443` |  |
 | fullnameOverride | string | `""` |  |
 | nameOverride | string | `""` |  |
 | prometheus.metricsBindAddress | string | `"127.0.0.1"` |  |

--- a/charts/frr-k8s/templates/webhooks.yaml
+++ b/charts/frr-k8s/templates/webhooks.yaml
@@ -121,6 +121,7 @@ spec:
             secretName: frr-k8s-webhook-server-cert
       serviceAccountName: {{ template "frrk8s.serviceAccountName" . }}
       terminationGracePeriodSeconds: 10
+      hostNetwork: true
 ---
 apiVersion: v1
 kind: Secret

--- a/charts/frr-k8s/templates/webhooks.yaml
+++ b/charts/frr-k8s/templates/webhooks.yaml
@@ -43,7 +43,6 @@ spec:
         - "--restart-on-rotator-secret-refresh=true"
         {{- end }}
         - "--namespace=$(NAMESPACE)"
-        - "--metrics-bind-address=:{{ .Values.prometheus.metricsPort }}"
         env:
         - name: NAMESPACE
           valueFrom:
@@ -63,8 +62,6 @@ spec:
         ports:
         - containerPort: {{ .Values.frrk8s.webhookPort }}
           name: webhook
-        - containerPort: {{ .Values.prometheus.metricsPort }}
-          name: monitoring
         {{- if .Values.frrk8s.livenessProbe.enabled }}
         livenessProbe:
           httpGet:

--- a/charts/frr-k8s/values.yaml
+++ b/charts/frr-k8s/values.yaml
@@ -128,7 +128,7 @@ frrk8s:
   podAnnotations: {}
   labels:
     app: frr-k8s
-  webhookPort: 9443
+  webhookPort: 19443
   livenessProbe:
     enabled: true
     failureThreshold: 3

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -93,7 +93,7 @@ func main() {
 	flag.StringVar(&certServiceName, "cert-service-name", "frr-k8s-webhook-service", "The service name used to generate the TLS cert's hostname")
 	flag.StringVar(&pprofAddr, "pprof-bind-address", "", "The address the pprof endpoints bind to.")
 	flag.StringVar(&alwaysBlockCIDRs, "always-block", "", "a list of comma separated cidrs we need to always block")
-	flag.IntVar(&webhookPort, "webhook-port", 9443, "the port we listen the webhook calls on")
+	flag.IntVar(&webhookPort, "webhook-port", 19443, "the port we listen the webhook calls on")
 
 	opts := zap.Options{
 		Development: true,

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -111,7 +111,7 @@ func main() {
 		Field: fields.ParseSelectorOrDie(fmt.Sprintf("metadata.namespace=%s", namespace)),
 	}
 
-	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
+	options := ctrl.Options{
 		Scheme:                 scheme,
 		HealthProbeBindAddress: "", // we use the metrics endpoint for healthchecks
 		Cache: cache.Options{
@@ -128,7 +128,12 @@ func main() {
 			BindAddress: metricsAddr,
 		},
 		PprofBindAddress: pprofAddr,
-	})
+	}
+	enableWebhook := webhookMode == "onlywebhook"
+	if enableWebhook {
+		options.Metrics.BindAddress = "0" // disable metrics endpoint
+	}
+	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), options)
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")
 		os.Exit(1)
@@ -138,7 +143,6 @@ func main() {
 
 	//+kubebuilder:scaffold:builder
 
-	enableWebhook := webhookMode == "onlywebhook"
 	startListeners := make(chan struct{})
 	if enableWebhook && !disableCertRotation {
 		setupLog.Info("Starting certs generator")

--- a/config/all-in-one/frr-k8s-prometheus.yaml
+++ b/config/all-in-one/frr-k8s-prometheus.yaml
@@ -1074,7 +1074,6 @@ spec:
         - --log-level=info
         - --webhook-mode=onlywebhook
         - --namespace=$(NAMESPACE)
-        - --metrics-bind-address=:7572
         command:
         - /frr-k8s
         env:
@@ -1093,8 +1092,6 @@ spec:
           periodSeconds: 20
         name: frr-k8s-webhook-server
         ports:
-        - containerPort: 7572
-          name: monitoring
         - containerPort: 9443
           name: webhook
         readinessProbe:

--- a/config/all-in-one/frr-k8s-prometheus.yaml
+++ b/config/all-in-one/frr-k8s-prometheus.yaml
@@ -1121,6 +1121,7 @@ spec:
         - mountPath: /tmp/k8s-webhook-server/serving-certs
           name: cert
           readOnly: true
+      hostNetwork: true
       serviceAccountName: frr-k8s-daemon
       terminationGracePeriodSeconds: 10
       tolerations:

--- a/config/all-in-one/frr-k8s-prometheus.yaml
+++ b/config/all-in-one/frr-k8s-prometheus.yaml
@@ -1092,7 +1092,7 @@ spec:
           periodSeconds: 20
         name: frr-k8s-webhook-server
         ports:
-        - containerPort: 9443
+        - containerPort: 19443
           name: webhook
         readinessProbe:
           httpGet:

--- a/config/all-in-one/frr-k8s.yaml
+++ b/config/all-in-one/frr-k8s.yaml
@@ -1043,7 +1043,6 @@ spec:
         - --log-level=info
         - --webhook-mode=onlywebhook
         - --namespace=$(NAMESPACE)
-        - --metrics-bind-address=:7572
         command:
         - /frr-k8s
         env:
@@ -1062,8 +1061,6 @@ spec:
           periodSeconds: 20
         name: frr-k8s-webhook-server
         ports:
-        - containerPort: 7572
-          name: monitoring
         - containerPort: 9443
           name: webhook
         readinessProbe:

--- a/config/all-in-one/frr-k8s.yaml
+++ b/config/all-in-one/frr-k8s.yaml
@@ -1061,7 +1061,7 @@ spec:
           periodSeconds: 20
         name: frr-k8s-webhook-server
         ports:
-        - containerPort: 9443
+        - containerPort: 19443
           name: webhook
         readinessProbe:
           httpGet:

--- a/config/all-in-one/frr-k8s.yaml
+++ b/config/all-in-one/frr-k8s.yaml
@@ -1090,6 +1090,7 @@ spec:
         - mountPath: /tmp/k8s-webhook-server/serving-certs
           name: cert
           readOnly: true
+      hostNetwork: true
       serviceAccountName: frr-k8s-daemon
       terminationGracePeriodSeconds: 10
       tolerations:

--- a/config/frr-k8s/frr-k8s.yaml
+++ b/config/frr-k8s/frr-k8s.yaml
@@ -293,7 +293,7 @@ spec:
               - ALL
           readOnlyRootFilesystem: true
         ports:
-        - containerPort: 9443
+        - containerPort: 19443
           name: webhook
         livenessProbe:
           httpGet:

--- a/config/frr-k8s/frr-k8s.yaml
+++ b/config/frr-k8s/frr-k8s.yaml
@@ -339,3 +339,4 @@ spec:
             secretName: webhook-server-cert
       serviceAccountName: daemon
       terminationGracePeriodSeconds: 10
+      hostNetwork: true

--- a/config/frr-k8s/frr-k8s.yaml
+++ b/config/frr-k8s/frr-k8s.yaml
@@ -278,7 +278,6 @@ spec:
         - "--log-level=info"
         - "--webhook-mode=onlywebhook"
         - "--namespace=$(NAMESPACE)"
-        - "--metrics-bind-address=:7572"
         env:
         - name: NAMESPACE
           valueFrom:
@@ -294,8 +293,6 @@ spec:
               - ALL
           readOnlyRootFilesystem: true
         ports:
-        - containerPort: 7572
-          name: monitoring
         - containerPort: 9443
           name: webhook
         livenessProbe:


### PR DESCRIPTION
Backporting stopping listening to the metrics port when running in webhook mode as the webhook will run in hostnetwork.