### PR TITLE
Fix frr-reloader error capture with --stdout flag

### DIFF
--- a/frr-tools/reloader/frr-reloader.sh
+++ b/frr-tools/reloader/frr-reloader.sh
@@ -17,7 +17,7 @@ reload_frr() {
   kill_sleep
 
   echo "Checking the configuration file syntax"
-  if ! python3 /usr/lib/frr/frr-reload.py --test --stdout "$FILE_TO_RELOAD" 2>"$LAST_ERROR_FILE" | sed 's/password.*/password <retracted>/g'; then
+  if ! python3 /usr/lib/frr/frr-reload.py --test --stdout "$FILE_TO_RELOAD" >"$LAST_ERROR_FILE" 2>&1 | sed 's/password.*/password <retracted>/g'; then
     echo "Syntax error spotted: aborting.. $SECONDS seconds"
     cat "$LAST_ERROR_FILE" | sed 's/password.*/password <retracted>/g'
     echo -n "$(date +%s) failure"  > "$STATUSFILE"


### PR DESCRIPTION
FRR 10.4.1 changed frr-reload.py logging behavior: when using --stdout, errors now go to stdout instead of stderr. Changed redirection from 2>file to >file 2>&1 to capture all output in the error file while maintaining container log visibility.

https://github.com/FRRouting/frr/blob/master/tools/frr-reload.py

