### PR TITLE
Dockerfile: unpin FRR rpm

### DIFF
--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -43,13 +43,12 @@ ENV PYTHONDONTWRITEBYTECODE yes
 RUN INSTALL_PKGS=" \
 	tcpdump libpcap \
 	iproute iputils strace socat \
+	frr \
 	python3 \
 	podman-catatonit" && \
 	yum install -y --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False $INSTALL_PKGS
 
-RUN dnf -y update && \
-yum install -y --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False frr-8.5.3-4.el9 && \
-yum clean all && rm -rf /var/cache/yum/* && rm -rf /var/cache/yum
+RUN dnf -y update && yum clean all && rm -rf /var/cache/yum/* && rm -rf /var/cache/yum
 
 # frr.sh is the entry point. This script examines environment
 # variables to direct operation and configure ovn


### PR DESCRIPTION
Now that we have a new process to bump rpms,
we remove the temporary pinning that was set in place to avoid scenarios where the latest rpm breaks

