### PR TITLE
ci: use quick-k8s action for KinD cluster setup

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -159,6 +159,25 @@ jobs:
           sudo apt-get update
           sudo apt-get install linux-modules-extra-$(uname -r)
 
+      # Cluster creation is handled here by quick-k8s instead of inside the
+      # Makefile (hack/kind.sh). When `make deploy-with-prometheus` runs later,
+      # hack/kind.sh detects the existing cluster and exits early.
+      - name: Create KinD cluster
+        uses: palmsoftware/quick-k8s@v0.0.49
+        with:
+          clusterName: frr-k8s
+          ipFamily: ${{ matrix.ip-family }}
+          numWorkerNodes: 2 # matches original hack/kind.sh topology
+          workerNodeLabels: "node-role.kubernetes.io/worker=worker" # required by deploy node selectors
+          disableDefaultCni: false # use kindnet, no custom CNI needed
+          waitForPodsReady: true
+          installCalico: false # kindnet is sufficient
+
+      - name: Export kubeconfig for Makefile
+        run: |
+          mkdir -p bin
+          kind export kubeconfig --name frr-k8s --kubeconfig bin/kubeconfig
+
       - name: Download frr8ks images
         uses: actions/download-artifact@v4
         with:
@@ -215,6 +234,23 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install linux-modules-extra-$(uname -r) python3-pip arping ndisc6
+
+      # Cluster creation is handled here by quick-k8s instead of inside the
+      # Makefile (hack/kind.sh). When `make deploy-helm` runs later,
+      # hack/kind.sh detects the existing cluster and exits early.
+      - name: Create KinD cluster
+        uses: palmsoftware/quick-k8s@v0.0.49
+        with:
+          numWorkerNodes: 2 # matches original hack/kind.sh topology
+          workerNodeLabels: "node-role.kubernetes.io/worker=worker" # required by deploy node selectors
+          disableDefaultCni: false # use kindnet, no custom CNI needed
+          waitForPodsReady: true
+          installCalico: false # kindnet is sufficient
+
+      - name: Export kubeconfig for Makefile
+        run: |
+          mkdir -p bin
+          kind export kubeconfig --name kind --kubeconfig bin/kubeconfig
 
       - name: Download frr-k8s images
         uses: actions/download-artifact@v4


### PR DESCRIPTION
## Summary

- Replace the implicit KinD cluster creation (via `hack/kind.sh` inside `make deploy-*`) with an explicit [`palmsoftware/quick-k8s`](https://github.com/palmsoftware/quick-k8s) action step for both the `e2e` and `metallb_e2e` jobs
- quick-k8s handles disk optimization, binary installation/caching, cluster creation, and worker node labeling in a single action call
- When the Makefile later calls `hack/kind.sh`, it detects the existing cluster and exits early — no Makefile changes needed

## Existing adoption

quick-k8s is already used across several Red Hat ecosystem projects:

- [`redhat-best-practices-for-k8s/certsuite`](https://github.com/redhat-best-practices-for-k8s/certsuite/blob/main/.github/actions/setup-partner-cluster/action.yml#L20)
- [`redhat-best-practices-for-k8s/certsuite-qe`](https://github.com/redhat-best-practices-for-k8s/certsuite-qe/blob/main/.github/workflows/qe.yml#L213)
- [`redhat-best-practices-for-k8s/collector`](https://github.com/redhat-best-practices-for-k8s/collector/blob/main/.github/workflows/nightly-sanity-check.yaml#L46)
- [`redhat-best-practices-for-k8s/certsuite-operator`](https://github.com/redhat-best-practices-for-k8s/certsuite-operator/blob/main/.github/workflows/pre-main.yaml#L94)
- [`redhat-best-practices-for-k8s/certsuite-sample-workload`](https://github.com/redhat-best-practices-for-k8s/certsuite-sample-workload/blob/main/.github/workflows/pre-main.yml#L68)
- [`rh-ecosystem-edge/eco-goinfra`](https://github.com/rh-ecosystem-edge/eco-goinfra/blob/main/.github/workflows/integration-testing.yml#L32)

## Test plan

- [ ] `e2e` matrix (ipv4/ipv6/dual x manifests/helm) passes with quick-k8s cluster
- [ ] `metallb_e2e` job passes with quick-k8s cluster
- [ ] Worker nodes are labeled with `node-role.kubernetes.io/worker=worker`
