### PR TITLE
OCPBUGS-84304: Bump to frr 10

### DIFF
--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -51,12 +51,11 @@ ENV PYTHONDONTWRITEBYTECODE yes
 RUN INSTALL_PKGS=" \
 	tcpdump libpcap \
 	iproute iputils strace socat \
-	frr \
+	frr10 \
 	python3 \
 	podman-catatonit" && \
-	yum install -y --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False $INSTALL_PKGS
-
-RUN dnf -y update && yum clean all && rm -rf /var/cache/yum/* && rm -rf /var/cache/yum
+	dnf install -y --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False $INSTALL_PKGS && \
+	dnf clean all && rm -rf /var/cache/yum
 
 # frr.sh is the entry point. This script examines environment
 # variables to direct operation and configure ovn


### PR DESCRIPTION
Bump to FRR 10 to be able to consume EVPN features in an [SVD configuration](https://docs.frrouting.org/en/latest/evpn.html#vlan-filtering-bridge-and-single-vxlan-device).

This feature is used by OVN-Kubernetes using raw config for now but there are upstream PRs to add API: https://github.com/metallb/frr-k8s/pull/419

Right now the version used is FRR 10.4.3

Also fixes https://redhat.atlassian.net/browse/OCPBUGS-84304

/kind feature
/kind bug
