### PR TITLE
OCPBUGS-84960: [release-4.22]: Bump to frr10

### DIFF
--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -51,12 +51,11 @@ ENV PYTHONDONTWRITEBYTECODE yes
 RUN INSTALL_PKGS=" \
 	tcpdump libpcap \
 	iproute iputils strace socat \
-	frr \
+	frr10 \
 	python3 \
 	podman-catatonit" && \
-	yum install -y --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False $INSTALL_PKGS
-
-RUN dnf -y update && yum clean all && rm -rf /var/cache/yum/* && rm -rf /var/cache/yum
+	dnf install -y --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False $INSTALL_PKGS && \
+	dnf clean all && rm -rf /var/cache/yum
 
 # frr.sh is the entry point. This script examines environment
 # variables to direct operation and configure ovn


### PR DESCRIPTION
Bump to FRR 10 to be able to consume EVPN features in an SVD configuration. This feature is used by OVN-Kubernetes using raw config for now but there are upstream PRs to add API: metallb/frr-k8s#419

Right now the version used is FRR 10.4.3

Fixes https://redhat.atlassian.net/browse/OCPBUGS-84960

/kind feature
/kind bug


(cherry picked from commit 0379925bc03a08ae5ac5489023d19bdc5c536d08)

