### PR TITLE
OCPBUGS-86568: Generate fallback BGP router-id on IPv6-only nodes

### DIFF
--- a/cmd/frr-k8s-controller/main.go
+++ b/cmd/frr-k8s-controller/main.go
@@ -140,7 +140,11 @@ func startFRRControllers(ctx context.Context, mgr manager.Manager, params params
 	reloadStatus := func() {
 		reloadStatusChan <- controller.NewStateEvent()
 	}
-	frrInstance := frr.NewFRR(ctx, reloadStatus, logger, logging.Level(params.logLevel))
+	frrInstance, err := frr.NewFRR(ctx, reloadStatus, logger, logging.Level(params.logLevel))
+	if err != nil {
+		setupLog.Error(err, "failed to create FRR instance")
+		os.Exit(1)
+	}
 
 	alwaysBlock, err := parseCIDRs(params.alwaysBlockCIDRs)
 	if err != nil {

--- a/internal/frr/frr.go
+++ b/internal/frr/frr.go
@@ -4,7 +4,10 @@ package frr
 
 import (
 	"context"
+	"encoding/binary"
 	"fmt"
+	"hash/crc32"
+	"net"
 	"os"
 	"strings"
 	"sync"
@@ -32,10 +35,11 @@ type Status struct {
 }
 
 type FRR struct {
-	reloadConfig    chan reloadEvent
-	logLevel        string
-	Status          Status
-	onStatusChanged StatusChanged
+	reloadConfig     chan reloadEvent
+	logLevel         string
+	Status           Status
+	onStatusChanged  StatusChanged
+	fallbackRouterID string
 	sync.Mutex
 }
 
@@ -54,14 +58,46 @@ func (f *FRR) ApplyConfig(config *Config) error {
 	// TODO add internal wrapper
 	config.Loglevel = f.logLevel
 	config.Hostname = hostname
+	if f.fallbackRouterID != "" {
+		for _, r := range config.Routers {
+			if r.RouterID == "" {
+				r.RouterID = f.fallbackRouterID
+			}
+		}
+	}
 	f.reloadConfig <- reloadEvent{config: config}
 	return nil
+}
+
+var netInterfaceAddrs = net.InterfaceAddrs
+
+func hasIPv4Address() bool {
+	addrs, err := netInterfaceAddrs()
+	if err != nil {
+		return false
+	}
+	for _, a := range addrs {
+		if ipnet, ok := a.(*net.IPNet); ok && ipnet.IP.To4() != nil {
+			return true
+		}
+	}
+	return false
+}
+
+func hashRouterID() (string, error) {
+	hostname, err := osHostname()
+	if err != nil {
+		return "", err
+	}
+	b := make([]byte, 4)
+	binary.LittleEndian.PutUint32(b, crc32.ChecksumIEEE([]byte(hostname)))
+	return net.IP(b).String(), nil
 }
 
 var debounceTimeout = 3 * time.Second
 var failureTimeout = time.Second * 5
 
-func NewFRR(ctx context.Context, onStatusChanged StatusChanged, logger log.Logger, logLevel logging.Level) *FRR {
+func NewFRR(ctx context.Context, onStatusChanged StatusChanged, logger log.Logger, logLevel logging.Level) (*FRR, error) {
 	res := &FRR{
 		reloadConfig:    make(chan reloadEvent),
 		logLevel:        logLevelToFRR(logLevel),
@@ -71,9 +107,19 @@ func NewFRR(ctx context.Context, onStatusChanged StatusChanged, logger log.Logge
 		return generateAndReloadConfigFile(config, logger)
 	}
 
+	// On IPv6-only nodes, FRR defaults router-id to 0.0.0.0 (RFC 6286 violation).
+	if !hasIPv4Address() {
+		routerID, err := hashRouterID()
+		if err != nil {
+			return nil, fmt.Errorf("failed to generate fallback router-id: %w", err)
+		}
+		res.fallbackRouterID = routerID
+		level.Info(logger).Log("op", "startup", "msg", "no IPv4 address found, using fallback router-id", "routerID", res.fallbackRouterID)
+	}
+
 	debouncer(ctx, reload, res.reloadConfig, debounceTimeout, failureTimeout, logger)
 	res.pollStatus(ctx, logger)
-	return res
+	return res, nil
 }
 
 func (f *FRR) GetStatus() Status {

--- a/internal/frr/frr_bfd_test.go
+++ b/internal/frr/frr_bfd_test.go
@@ -6,16 +6,14 @@ import (
 	"context"
 	"testing"
 
-	"github.com/go-kit/log"
 	"github.com/metallb/frr-k8s/internal/ipfamily"
-	"github.com/metallb/frr-k8s/internal/logging"
 	"k8s.io/utils/ptr"
 )
 
 func TestSingleSessionBFD(t *testing.T) {
 	testSetup(t)
 	ctx, cancel := context.WithCancel(context.Background())
-	frr := NewFRR(ctx, func() {}, log.NewNopLogger(), logging.LevelInfo)
+	frr := testNewFRR(t, ctx)
 	defer cancel()
 
 	config := Config{
@@ -58,7 +56,7 @@ func TestSingleSessionBFD(t *testing.T) {
 func TestTwoRoutersTwoNeighborsBFD(t *testing.T) {
 	testSetup(t)
 	ctx, cancel := context.WithCancel(context.Background())
-	frr := NewFRR(ctx, func() {}, log.NewNopLogger(), logging.LevelInfo)
+	frr := testNewFRR(t, ctx)
 	defer cancel()
 
 	config := Config{

--- a/internal/frr/frr_test.go
+++ b/internal/frr/frr_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -80,6 +81,15 @@ func testSetup(t *testing.T) {
 	osHostname = testOsHostname
 }
 
+func testNewFRR(t *testing.T, ctx context.Context) *FRR {
+	t.Helper()
+	frr, err := NewFRR(ctx, emptyCB, log.NewNopLogger(), logging.LevelInfo)
+	if err != nil {
+		t.Fatalf("Failed to create FRR instance: %s", err)
+	}
+	return frr
+}
+
 func testCheckConfigFile(t *testing.T) {
 	configFile, goldenFile := testGenerateFileNames(t)
 
@@ -102,7 +112,7 @@ var emptyCB = func() {}
 func TestSingleSession(t *testing.T) {
 	testSetup(t)
 	ctx, cancel := context.WithCancel(context.Background())
-	frr := NewFRR(ctx, emptyCB, log.NewNopLogger(), logging.LevelInfo)
+	frr := testNewFRR(t, ctx)
 	defer cancel()
 
 	config := Config{
@@ -138,7 +148,7 @@ func TestSingleSession(t *testing.T) {
 func TestTwoRoutersTwoNeighbors(t *testing.T) {
 	testSetup(t)
 	ctx, cancel := context.WithCancel(context.Background())
-	frr := NewFRR(ctx, emptyCB, log.NewNopLogger(), logging.LevelInfo)
+	frr := testNewFRR(t, ctx)
 	defer cancel()
 
 	config := Config{
@@ -203,7 +213,7 @@ func TestTwoRoutersTwoNeighbors(t *testing.T) {
 func TestTwoSessionsAcceptAll(t *testing.T) {
 	testSetup(t)
 	ctx, cancel := context.WithCancel(context.Background())
-	frr := NewFRR(ctx, emptyCB, log.NewNopLogger(), logging.LevelInfo)
+	frr := testNewFRR(t, ctx)
 	defer cancel()
 
 	config := Config{
@@ -241,7 +251,7 @@ func TestTwoSessionsAcceptAll(t *testing.T) {
 func TestTwoSessionsAcceptSomeV4(t *testing.T) {
 	testSetup(t)
 	ctx, cancel := context.WithCancel(context.Background())
-	frr := NewFRR(ctx, emptyCB, log.NewNopLogger(), logging.LevelInfo)
+	frr := testNewFRR(t, ctx)
 	defer cancel()
 
 	config := Config{
@@ -293,7 +303,7 @@ func TestTwoSessionsAcceptSomeV4(t *testing.T) {
 func TestTwoSessionsAcceptV4AndV6(t *testing.T) {
 	testSetup(t)
 	ctx, cancel := context.WithCancel(context.Background())
-	frr := NewFRR(ctx, emptyCB, log.NewNopLogger(), logging.LevelInfo)
+	frr := testNewFRR(t, ctx)
 	defer cancel()
 
 	config := Config{
@@ -412,7 +422,7 @@ func TestSingleSessionWithEBGPMultihop(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	frr := NewFRR(ctx, emptyCB, log.NewNopLogger(), logging.LevelInfo)
+	frr := testNewFRR(t, ctx)
 
 	config := Config{
 		Routers: []*RouterConfig{
@@ -449,7 +459,7 @@ func TestSingleSessionWithIPv6SingleHop(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	frr := NewFRR(ctx, emptyCB, log.NewNopLogger(), logging.LevelInfo)
+	frr := testNewFRR(t, ctx)
 
 	config := Config{
 		Routers: []*RouterConfig{
@@ -486,7 +496,7 @@ func TestMultipleNeighborsOneV4AndOneV6(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	frr := NewFRR(ctx, emptyCB, log.NewNopLogger(), logging.LevelInfo)
+	frr := testNewFRR(t, ctx)
 
 	config := Config{
 		Routers: []*RouterConfig{
@@ -534,7 +544,7 @@ func TestMultipleNeighborsOneV4AndOneV6DualStackIPFamily(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	frr := NewFRR(ctx, emptyCB, log.NewNopLogger(), logging.LevelInfo)
+	frr := testNewFRR(t, ctx)
 
 	config := Config{
 		Routers: []*RouterConfig{
@@ -581,7 +591,7 @@ func TestMultipleRoutersMultipleNeighs(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	frr := NewFRR(ctx, emptyCB, log.NewNopLogger(), logging.LevelInfo)
+	frr := testNewFRR(t, ctx)
 
 	config := Config{
 		Routers: []*RouterConfig{
@@ -656,7 +666,7 @@ func TestSingleSessionWithEBGPMultihopAndExtras(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	frr := NewFRR(ctx, emptyCB, log.NewNopLogger(), logging.LevelInfo)
+	frr := testNewFRR(t, ctx)
 
 	config := Config{
 		Routers: []*RouterConfig{
@@ -694,7 +704,7 @@ func TestSingleSessionWithAlwaysBlock(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	frr := NewFRR(ctx, emptyCB, log.NewNopLogger(), logging.LevelInfo)
+	frr := testNewFRR(t, ctx)
 
 	config := Config{
 		Routers: []*RouterConfig{
@@ -765,7 +775,7 @@ func TestSingleSessionWithGracefulRestart(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	frr := NewFRR(ctx, emptyCB, log.NewNopLogger(), logging.LevelInfo)
+	frr := testNewFRR(t, ctx)
 
 	config := Config{
 		Routers: []*RouterConfig{
@@ -797,7 +807,7 @@ func TestMultipleRoutersImportVRFs(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	frr := NewFRR(ctx, emptyCB, log.NewNopLogger(), logging.LevelInfo)
+	frr := testNewFRR(t, ctx)
 
 	config := Config{
 		Routers: []*RouterConfig{
@@ -841,7 +851,7 @@ func TestMultipleRoutersImportVRFs(t *testing.T) {
 func TestSingleSessionWithInternalASN(t *testing.T) {
 	testSetup(t)
 	ctx, cancel := context.WithCancel(context.Background())
-	frr := NewFRR(ctx, emptyCB, log.NewNopLogger(), logging.LevelInfo)
+	frr := testNewFRR(t, ctx)
 	defer cancel()
 
 	config := Config{
@@ -875,7 +885,7 @@ func TestSingleSessionWithInternalASN(t *testing.T) {
 func TestSingleSessionWithExternalASN(t *testing.T) {
 	testSetup(t)
 	ctx, cancel := context.WithCancel(context.Background())
-	frr := NewFRR(ctx, emptyCB, log.NewNopLogger(), logging.LevelInfo)
+	frr := testNewFRR(t, ctx)
 	defer cancel()
 
 	config := Config{
@@ -908,7 +918,7 @@ func TestSingleSessionWithExternalASN(t *testing.T) {
 func TestSingleUnnumberedSession(t *testing.T) {
 	testSetup(t)
 	ctx, cancel := context.WithCancel(context.Background())
-	frr := NewFRR(ctx, emptyCB, log.NewNopLogger(), logging.LevelInfo)
+	frr := testNewFRR(t, ctx)
 	defer cancel()
 
 	config := Config{
@@ -928,6 +938,82 @@ func TestSingleUnnumberedSession(t *testing.T) {
 					},
 				},
 				IPV4Prefixes: []string{"192.169.1.0/24", "192.170.1.0/22"},
+			},
+		},
+	}
+	err := frr.ApplyConfig(&config)
+	if err != nil {
+		t.Fatalf("Failed to apply config: %s", err)
+	}
+
+	testCheckConfigFile(t)
+}
+
+func TestSingleSessionExplicitRouterID(t *testing.T) {
+	testSetup(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	frr := testNewFRR(t, ctx)
+	defer cancel()
+
+	config := Config{
+		Routers: []*RouterConfig{
+			{
+				MyASN:    65000,
+				RouterID: "10.10.10.1",
+				Neighbors: []*NeighborConfig{
+					{
+						IPFamily: ipfamily.IPv4,
+						ASN:      "65001",
+						Addr:     "192.168.1.2",
+						Port:     ptr.To[uint16](4567),
+						Outgoing: AllowedOut{
+							PrefixesV4: []string{
+								"192.169.1.0/24",
+							},
+						},
+					},
+				},
+				IPV4Prefixes: []string{"192.169.1.0/24"},
+			},
+		},
+	}
+	err := frr.ApplyConfig(&config)
+	if err != nil {
+		t.Fatalf("Failed to apply config: %s", err)
+	}
+
+	testCheckConfigFile(t)
+}
+
+func TestSingleSessionIPv6OnlyNode(t *testing.T) {
+	testSetup(t)
+	netInterfaceAddrs = func() ([]net.Addr, error) {
+		return nil, nil
+	}
+	t.Cleanup(func() { netInterfaceAddrs = net.InterfaceAddrs })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	frr := testNewFRR(t, ctx)
+	defer cancel()
+
+	config := Config{
+		Routers: []*RouterConfig{
+			{
+				MyASN: 65000,
+				Neighbors: []*NeighborConfig{
+					{
+						IPFamily: ipfamily.IPv6,
+						ASN:      "65001",
+						Addr:     "2001:db8::1",
+						Port:     ptr.To[uint16](179),
+						Outgoing: AllowedOut{
+							PrefixesV6: []string{
+								"2001:db8:1::/64",
+							},
+						},
+					},
+				},
+				IPV6Prefixes: []string{"2001:db8:1::/64"},
 			},
 		},
 	}

--- a/internal/frr/testdata/TestSingleSessionExplicitRouterID.golden
+++ b/internal/frr/testdata/TestSingleSessionExplicitRouterID.golden
@@ -1,0 +1,54 @@
+log stdout informational
+log timestamp precision 3
+hostname dummyhostname
+ip nht resolve-via-default
+ipv6 nht resolve-via-default
+
+
+
+ip prefix-list 192.168.1.2-allowed-ipv4 seq 1 permit 192.169.1.0/24
+
+
+ipv6 prefix-list 192.168.1.2-allowed-ipv6 seq 1 deny any
+
+route-map 192.168.1.2-out permit 1
+  match ip address prefix-list 192.168.1.2-allowed-ipv4
+
+route-map 192.168.1.2-out permit 2
+  match ipv6 address prefix-list 192.168.1.2-allowed-ipv6
+
+
+
+
+
+ip prefix-list 192.168.1.2-inpl-ipv4 seq 1 deny any
+
+ipv6 prefix-list 192.168.1.2-inpl-ipv4 seq 2 deny any
+route-map 192.168.1.2-in permit 3
+  match ip address prefix-list 192.168.1.2-inpl-ipv4
+route-map 192.168.1.2-in permit 4
+  match ipv6 address prefix-list 192.168.1.2-inpl-ipv4
+
+router bgp 65000
+  no bgp ebgp-requires-policy
+  no bgp network import-check
+  no bgp default ipv4-unicast
+  bgp graceful-restart preserve-fw-state
+
+  bgp router-id 10.10.10.1
+  neighbor 192.168.1.2 remote-as 65001
+  neighbor 192.168.1.2 port 4567
+  
+  
+  
+
+  address-family ipv4 unicast
+    neighbor 192.168.1.2 activate
+    neighbor 192.168.1.2 route-map 192.168.1.2-in in
+    neighbor 192.168.1.2 route-map 192.168.1.2-out out
+  exit-address-family
+  address-family ipv4 unicast
+    network 192.169.1.0/24
+  exit-address-family
+
+

--- a/internal/frr/testdata/TestSingleSessionIPv6OnlyNode.golden
+++ b/internal/frr/testdata/TestSingleSessionIPv6OnlyNode.golden
@@ -1,0 +1,55 @@
+log stdout informational
+log timestamp precision 3
+hostname dummyhostname
+ip nht resolve-via-default
+ipv6 nht resolve-via-default
+
+
+
+ip prefix-list 2001:db8::1-allowed-ipv4 seq 1 deny any
+
+
+ipv6 prefix-list 2001:db8::1-allowed-ipv6 seq 1 permit 2001:db8:1::/64
+
+route-map 2001:db8::1-out permit 1
+  match ip address prefix-list 2001:db8::1-allowed-ipv4
+
+route-map 2001:db8::1-out permit 2
+  match ipv6 address prefix-list 2001:db8::1-allowed-ipv6
+
+
+
+
+
+ip prefix-list 2001:db8::1-inpl-ipv6 seq 1 deny any
+
+ipv6 prefix-list 2001:db8::1-inpl-ipv6 seq 2 deny any
+route-map 2001:db8::1-in permit 3
+  match ip address prefix-list 2001:db8::1-inpl-ipv6
+route-map 2001:db8::1-in permit 4
+  match ipv6 address prefix-list 2001:db8::1-inpl-ipv6
+
+router bgp 65000
+  no bgp ebgp-requires-policy
+  no bgp network import-check
+  no bgp default ipv4-unicast
+  bgp graceful-restart preserve-fw-state
+
+  bgp router-id 167.62.253.30
+  neighbor 2001:db8::1 remote-as 65001
+  neighbor 2001:db8::1 port 179
+  
+  
+  
+  neighbor 2001:db8::1 disable-connected-check
+
+  address-family ipv6 unicast
+    neighbor 2001:db8::1 activate
+    neighbor 2001:db8::1 route-map 2001:db8::1-in in
+    neighbor 2001:db8::1 route-map 2001:db8::1-out out
+  exit-address-family
+  address-family ipv6 unicast
+    network 2001:db8:1::/64
+  exit-address-family
+
+


### PR DESCRIPTION
Cherry-picked from
* https://github.com/openshift/frr/pull/132
* https://github.com/metallb/frr-k8s/pull/445